### PR TITLE
Unique given sources

### DIFF
--- a/src/main/php/xp/lambda/PackageLambda.class.php
+++ b/src/main/php/xp/lambda/PackageLambda.class.php
@@ -54,8 +54,9 @@ class PackageLambda {
     $z= ZipFile::create($this->target->asFile()->out());
 
     $sources= [...$this->sources];
+    $total= sizeof($sources) + 1;
     foreach ($sources as $i => $source) {
-      Console::writef("\e[34m => [%d/%d] ", $i + 1, sizeof($sources) + 1);
+      Console::writef("\e[34m => [%d/%d] ", $i + 1, $total);
       $entries= 0;
       foreach ($this->entries(new Path($source)) as $action) {
         $entry= $action($z);
@@ -67,7 +68,7 @@ class PackageLambda {
 
     $file= $z->add(new ZipFileEntry('class.pth'));
     $file->out()->write(preg_replace($this->exclude.'m', '?$1', file_get_contents('class.pth')));
-    Console::writeLinef("\e[34m => [%1\$d/%1\$d] class.pth\e[0m", sizeof($sources) + 1);
+    Console::writeLinef("\e[34m => [%1\$d/%1\$d] class.pth\e[0m", $total);
 
     $z->close();
     Console::writeLine();

--- a/src/main/php/xp/lambda/PackageLambda.class.php
+++ b/src/main/php/xp/lambda/PackageLambda.class.php
@@ -29,7 +29,7 @@ class PackageLambda {
   private function entries(Path $path) {
     if (preg_match($this->exclude, $path->toString('/'))) return;
 
-    $relative= trim(str_replace($this->sources->base, '', $path), DIRECTORY_SEPARATOR);
+    $relative= $path->relativeTo($this->sources->base);
     if ($path->isFile()) {
       yield function($z) use($relative, $path) {
         $file= $z->add(new ZipFileEntry($relative));

--- a/src/main/php/xp/lambda/Runner.class.php
+++ b/src/main/php/xp/lambda/Runner.class.php
@@ -52,7 +52,7 @@ class Runner {
   private static function command(string $name, array $args): object {
     sscanf($name, "%[^:]:%[^\r]", $command, $version);
     switch ($command) {
-      case 'package': return new PackageLambda(new Path('function.zip'), new Path('.'), [...$args, 'src', 'vendor']);
+      case 'package': return new PackageLambda(new Path('function.zip'), new Sources(new Path('.'), [...$args, 'src', 'vendor']));
       case 'runtime': return new CreateRuntime(self::resolve($version), new Path('runtime-%s.zip'), in_array('-b', $args));
       case 'test': return new TestLambda(self::resolve($version), new Path('.'), $args[0] ?? 'Handler', $args[1] ?? '{}');
       default: return new DisplayError('Unknown command "'.$args[0].'"');

--- a/src/main/php/xp/lambda/Sources.class.php
+++ b/src/main/php/xp/lambda/Sources.class.php
@@ -1,0 +1,28 @@
+<?php namespace xp\lambda;
+
+use IteratorAggregate, Traversable;
+use io\Path;
+
+/** Returns a unique list of sources */
+class Sources implements IteratorAggregate {
+  public $base;
+  private $sources;
+
+  public function __construct(Path $base, array $sources) {
+    $this->base= $base->asRealpath();
+    $this->sources= $sources;
+  }
+
+  public function getIterator(): Traversable {
+    $seen= [];
+    foreach ($this->sources as $source) {
+      $path= ($source instanceof Path ? $source : new Path($source))->asRealpath();
+
+      $key= $path->hashCode(); 
+      if (isset($seen[$key])) continue;
+
+      yield $path;
+      $seen[$key]= true;
+    }
+  }
+}

--- a/src/test/php/com/amazon/aws/lambda/unittest/SourcesTest.class.php
+++ b/src/test/php/com/amazon/aws/lambda/unittest/SourcesTest.class.php
@@ -1,0 +1,79 @@
+<?php namespace com\amazon\aws\lambda\unittest;
+
+use io\{Folder, File, Path};
+use lang\Environment;
+use unittest\{Assert, After, Test, Values};
+use xp\lambda\Sources;
+
+class SourcesTest {
+  private $cleanup= [];
+
+  /** Creates a directory given a layout */
+  private function directory(array $layout): Path {
+    $dir= new Folder(Environment::tempDir(), uniqid());
+    $dir->create() && $this->cleanup[]= $dir;
+
+    foreach ($layout as $name => $contents) {
+      if (null === $contents) {
+        $f= new Folder($dir, $name);
+        $f->create();
+      } else {
+        $f= new File($dir, $name);
+        $f->touch();
+      }
+    }
+
+    return new Path($dir);
+  }
+
+  #[After]
+  public function cleanup() {
+    foreach ($this->cleanup as $folder) {
+      $folder->unlink();
+    }
+  }
+
+  #[Test]
+  public function can_create() {
+    new Sources(new Path('.'), []);
+  }
+
+  #[Test, Values([[['%s/test.txt']], [['%s/test.txt', '%s/test.txt', '%s/./test.txt', '%s/../%s/test.txt']]])]
+  public function with_one_file($sources) {
+    $dir= $this->directory(['test.txt' => 'Test']);
+
+    Assert::equals(
+      [new Path($dir, 'test.txt')],
+      iterator_to_array(new Sources($dir, array_map(
+        function($source) use($dir) { return sprintf($source, $dir, $dir->name()); },
+        $sources
+      )))
+    );
+  }
+
+  #[Test, Values([[['%s/src']], [['%s/src', '%s/src', '%s/./src', '%s/../%s/src']]])]
+  public function with_one_directory($sources) {
+    $dir= $this->directory(['src' => null]);
+
+    Assert::equals(
+      [new Path($dir, 'src')],
+      iterator_to_array(new Sources($dir, array_map(
+        function($source) use($dir) { return sprintf($source, $dir, $dir->name()); },
+        $sources
+      )))
+    );
+  }
+
+  #[Test, Values([[['%s/src', '%s/vendor', '%s/test.txt']], [['%s/src', '%s/vendor', '%s/test.txt', '%s/src', '%s/./vendor']]])]
+  public function with_files_and_directories($sources) {
+    $dir= $this->directory(['src' => null, 'vendor' => null, 'test.txt' => 'Test']);
+
+    Assert::equals(
+      [new Path($dir, 'src'), new Path($dir, 'vendor'), new Path($dir, 'test.txt')],
+      iterator_to_array(new Sources($dir,  array_map(
+        function($source) use($dir) { return sprintf($source, $dir, $dir->name()); },
+        $sources
+      )))
+    );
+  }
+}


### PR DESCRIPTION
This pull request uniques the source files and directories given on the command line to prevent adding them to the ZIP file twice. The problem is only visible in the file size and in the output, ZIP file readers will ignore duplicate entries when extracting. 

*In the following examples, the user has supplied the `src` directory, although the packaging command already includes it!*

### Before
```bash
$ xp lambda package Greet.class.php src
 => [1/5] Greet.class.php                                                 1
 => [2/5] src/main/php/xp/lambda/TestLambda.class.php                    23
 => [3/5] src/main/php/xp/lambda/TestLambda.class.php                    23
 => [4/5] mework/zip/src/main/php/io/archive/zip/ZipIterator.class.php  534
 => [5/5] class.pth

Wrote 572,174 bytes
```
### After
```bash
$ xp lambda package Greet.class.php src
[+] Creating function.zip (compression: GZ)
 => [1/4] Greet.class.php                                                 1
 => [2/4] src/main/php/xp/lambda/TestLambda.class.php                    23
 => [3/4] mework/zip/src/main/php/io/archive/zip/ZipIterator.class.php  534
 => [4/4] class.pth

Wrote 562,537 bytes
```