### PR TITLE
Refactor container execution to Process API provided by XP 10.14

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,14 +6,14 @@
   "description" : "AWS Lambda for the XP Framework",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^10.0 | ^9.0 | ^8.0 | ^7.0",
-    "xp-framework/http": "^10.0 | ^9.0 | ^8.0 | ^7.0",
-    "xp-framework/zip": "^9.0 | ^8.0 | ^7.0",
+    "xp-framework/core": "^10.14",
+    "xp-framework/http": "^10.0 | ^9.0",
+    "xp-framework/zip": "^9.0 | ^8.0",
     "xp-forge/json": "^4.0",
     "php": ">=7.0.0"
   },
   "require-dev" : {
-    "xp-framework/unittest": "^11.0 | ^10.0 | ^9.0 | ^8.0 |^7.0"
+    "xp-framework/unittest": "^11.0 | ^10.0"
   },
   "bin": ["bin/xp.xp-forge.lambda"],
   "autoload" : {

--- a/src/main/php/xp/lambda/CreateRuntime.class.php
+++ b/src/main/php/xp/lambda/CreateRuntime.class.php
@@ -15,7 +15,6 @@ class CreateRuntime {
   }
 
   public function run(): int {
-    $docker= $this->command();
 
     // Build test and runtime containers when -b is given
     if ($this->rebuild) {
@@ -29,20 +28,20 @@ class CreateRuntime {
     $code= "echo ' => PHP ', PHP_VERSION, ' & Zend ', zend_version(), ' @ ', php_uname(), PHP_EOL, ' => ', implode(' ', get_loaded_extensions()), PHP_EOL;";
     Console::writeLine();
     Console::writeLine("[+] Running {$runtime}\e[34m");
-    passthru("{$docker} run --rm {$runtime} /opt/php/bin/php -r \"{$code}\"", $result);
+    $this->passthru(['run', '--rm', $runtime, '/opt/php/bin/php', '-r', $code]);
     Console::writeLine("\e[0m");
 
     // Extract runtime
     $container= uniqid();
     $commands= [
-      "{$docker} create --name {$container} {$runtime}",
-      "{$docker} cp {$container}:/opt/php/runtime.zip {$this->target}",
-      "{$docker} rm -f {$container}",
+      ['create', '--name', $container, $runtime],
+      ['cp', "{$container}:/opt/php/runtime.zip", $this->target],
+      ['rm', '-f', $container],
     ];
     Console::writeLine('[+] Creating ', $this->target);
     foreach ($commands as $command) {
-      Console::writeLinef("\e[34m => %s\e[0m", $command);
-      exec($command, $out, $result);
+      Console::writeLinef("\e[34m => %s\e[0m", implode(' ', $command));
+      $result= $this->passthru($command);
     }
 
     Console::writeLine();

--- a/src/main/php/xp/lambda/TestLambda.class.php
+++ b/src/main/php/xp/lambda/TestLambda.class.php
@@ -16,12 +16,9 @@ class TestLambda {
   }
 
   public function run(): int {
-    $docker= $this->command();
     $test= $this->image('test', $this->version, ['runtime' => []])['test'];
     if (null === $test) return 1;
 
-    $payload= '"'.str_replace('"', '\\"', $this->payload).'"';
-    passthru("{$docker} run --rm -v {$this->path}:/var/task:ro {$test} {$this->handler} {$payload}", $result);
-    return $result;
+    return $this->passthru(['run', '--rm', '-v', "{$this->path}:/var/task:ro", $test, $this->handler, $this->payload]);
   }
 }


### PR DESCRIPTION
See xp-framework/core#281 and xp-framework/core#282. 

⚠️ Breaks BC by requiring [XP 10.14](https://github.com/xp-framework/core/releases/tag/v10.14.0) and no longer having support for XP 9 and below (see https://github.com/xp-framework/rfc/issues/341), and will thus create a new major release.
