### PR TITLE
Add ability to pass environment variables to tested lambda

### DIFF
--- a/src/main/php/xp/lambda/Runner.class.php
+++ b/src/main/php/xp/lambda/Runner.class.php
@@ -24,6 +24,10 @@ use text\json\{Json, StreamInput};
  *   ```sh
  *   $ xp lambda test Greet '{"name":"Test"}'
  *   ```
+ * - Test lambda, pass environment variables:
+ *   ```sh
+ *   $ xp lambda test -e PROFILE=prod Audit
+ *   ```
  * - Package single file in `function.zip` file for deployment:
  *   ```sh
  *   $ xp lambda package Greet.class.php
@@ -63,7 +67,7 @@ class Runner {
     switch ($command) {
       case 'package': return new PackageLambda(new Path('function.zip'), new Sources(new Path('.'), [...$args, 'vendor']));
       case 'runtime': return new CreateRuntime(self::resolve($version), new Path('runtime-%s.zip'), in_array('-b', $args));
-      case 'test': return new TestLambda(self::resolve($version), new Path('.'), $args[0] ?? 'Handler', $args[1] ?? '{}');
+      case 'test': return new TestLambda(self::resolve($version), new Path('.'), $args);
       default: return new DisplayError('Unknown command "'.$args[0].'"');
     }
   }


### PR DESCRIPTION
## Example

```php
use com\amazon\aws\lambda\Handler;

class Env extends Handler {

  /** @return com.amazon.aws.lambda.Lambda|callable */
  public function target() {
    return fn($event, $context) => sprintf(
      'Hello %s',
      $this->environment->variable('PROFILE') ?? 'default'
    );
  }
}
```

Invoking the lambda without passing the variable:

```bash
$ xp lambda test Env
START RequestId: 79bffe4e-226d-147a-c36a-7de3135248e8 Version: $LATEST
END RequestId: 79bffe4e-226d-147a-c36a-7de3135248e8
REPORT RequestId: 79bffe4e-226d-147a-c36a-7de3135248e8  Init Duration: 64.10 ms Duration: 4.78 ms
       Billed Duration: 5 ms     Memory Size: 1536 MB    Max Memory Used: 22 MB

"Hello default"
```

Passing the environment variable including a value:

```bash
$ xp lambda test -e PROFILE=testing Env
START RequestId: e51c92b4-e994-13ac-047a-e10ca56eced0 Version: $LATEST
END RequestId: e51c92b4-e994-13ac-047a-e10ca56eced0
REPORT RequestId: e51c92b4-e994-13ac-047a-e10ca56eced0  Init Duration: 52.45 ms Duration: 4.01 ms
       Billed Duration: 5 ms     Memory Size: 1536 MB    Max Memory Used: 24 MB

"Hello testing"
```

Passing the environment variable:

```bash
$ export PROFILE=testing
$ xp lambda test -e PROFILE Env
START RequestId: dab53651-6c21-1bab-7fa0-f62b7ef488fa Version: $LATEST
END RequestId: dab53651-6c21-1bab-7fa0-f62b7ef488fa
REPORT RequestId: dab53651-6c21-1bab-7fa0-f62b7ef488fa  Init Duration: 54.69 ms Duration: 3.98 ms
       Billed Duration: 4 ms     Memory Size: 1536 MB    Max Memory Used: 26 MB

"Hello testing"
```