### PR TITLE
Upgrade to Amazon Linux 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,10 @@ $ xp lambda test Greet '{"name":"Timm"}'
 START RequestId: 9ff45cda-df9b-1b8c-c21b-5fe27c8f2d24 Version: $LATEST
 END RequestId: 9ff45cda-df9b-1b8c-c21b-5fe27c8f2d24
 REPORT RequestId: 9ff45cda-df9b-1b8c-c21b-5fe27c8f2d24  Init Duration: 922.19 ms...
-
 "Hello Timm from PHP 8.0.10 via test @ us-east-1"
 ```
 
-*This functionality is provided by the great [LambCI Docker image](https://github.com/lambci/docker-lambda)!*
+*This functionality is provided by the [AWS Lambda base images for custom runtimes](https://gallery.ecr.aws/lambda/provided)*
 
 Setup
 -----

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ $ aws lambda create-function \
   --function-name greet \
   --handler Greet \
   --zip-file fileb://./function.zip \
-  --runtime provided \
+  --runtime provided.al2 \
   --role "arn:aws:iam::XXXXXXXXXXXX:role/service-role/InvokeLambda" \
   --region us-east-1 \
   --layers "arn:aws:lambda:us-east-1:XXXXXXXXXXXX:layer:lambda-xp-runtime:1"

--- a/src/main/php/xp/lambda/CreateRuntime.class.php
+++ b/src/main/php/xp/lambda/CreateRuntime.class.php
@@ -28,7 +28,7 @@ class CreateRuntime {
     $code= "echo ' => PHP ', PHP_VERSION, ' & Zend ', zend_version(), ' @ ', php_uname(), PHP_EOL, ' => ', implode(' ', get_loaded_extensions()), PHP_EOL;";
     Console::writeLine();
     Console::writeLine("[+] Running {$runtime}\e[34m");
-    $this->passthru(['run', '--rm', $runtime, '/opt/php/bin/php', '-r', $code]);
+    $this->passthru(['run', '--rm', '--entrypoint=/opt/php/bin/php', $runtime, '-r', $code]);
     Console::writeLine("\e[0m");
 
     // Extract runtime

--- a/src/main/php/xp/lambda/Dockerfile.runtime
+++ b/src/main/php/xp/lambda/Dockerfile.runtime
@@ -1,10 +1,7 @@
-FROM amazonlinux:2018.03.0.20210721.0 as builder
+FROM public.ecr.aws/lambda/provided:al2 as builder
 
 ARG php_version="?.?.?"
 ARG xp_version="?.?.?"
-
-# Install PHP build dependencies
-RUN curl -O http://mirror.centos.org/centos/7/os/x86_64/Packages/bison-3.0.4-2.el7.x86_64.rpm
 
 RUN yum clean all && yum install -y \
   autoconf \
@@ -15,8 +12,9 @@ RUN yum clean all && yum install -y \
   openssl-devel \
   libxml2-devel \
   tar \
+  gzip \
   zip \
-  bison-3.0.4-2.el7.x86_64.rpm
+  bison
 
 # Build PHP
 RUN curl -L https://github.com/php/php-src/archive/php-${php_version}.tar.gz | tar -xvz

--- a/src/main/php/xp/lambda/Dockerfile.test
+++ b/src/main/php/xp/lambda/Dockerfile.test
@@ -1,12 +1,21 @@
 ARG php_version="?.?.?"
 ARG xp_version="?.?.?"
 
-FROM lambda-xp-runtime:${php_version} as runtime
+FROM lambda-xp-runtime:${php_version} as build
 
-FROM lambci/lambda:provided
+FROM public.ecr.aws/lambda/provided:al2
 
-COPY --from=runtime /opt/php/bin/ /opt/bin/
+COPY --from=build /opt/php/bin/ /opt/bin/
 
-COPY --from=runtime /opt/php/bootstrap /opt/bootstrap
+COPY --from=build /opt/php/bootstrap /var/runtime/bootstrap
+
+# Overwrite AWS lambda entrypoint
+RUN echo $'#!/bin/sh\n\n\
+export _HANDLER="$1"\n\
+/usr/local/bin/aws-lambda-rie /var/runtime/bootstrap 2>/dev/null &\n\
+pid=$!\n\
+curl -s "http://localhost:8080/2015-03-31/functions/function/invocations" -d "$2"\n\
+kill -2 $pid\n\
+echo' > /lambda-entrypoint.sh
 
 ENV TZ UTC

--- a/src/main/php/xp/lambda/Dockerfile.test
+++ b/src/main/php/xp/lambda/Dockerfile.test
@@ -12,7 +12,7 @@ COPY --from=build /opt/php/bootstrap /var/runtime/bootstrap
 # Overwrite AWS lambda entrypoint
 RUN echo $'#!/bin/sh\n\n\
 export _HANDLER="$1"\n\
-/usr/local/bin/aws-lambda-rie /var/runtime/bootstrap 2>/dev/null &\n\
+/usr/local/bin/aws-lambda-rie /var/runtime/bootstrap --log-level error &\n\
 pid=$!\n\
 curl -s "http://localhost:8080/2015-03-31/functions/function/invocations" -d "$2"\n\
 kill -2 $pid\n\


### PR DESCRIPTION
This pull request:

* Upgrades from Amazon Linux 1 to [Amazon Linux 2](https://aws.amazon.com/amazon-linux-2/)
* Uses Bison 3 right from included packages instead of downloading an RPM
* Removes dependency on the [LambCI Docker image](https://github.com/lambci/docker-lambda)
