### PR TITLE
Make credentials accessible via Environment::credentials()

### DIFF
--- a/src/main/php/com/amazon/aws/lambda/Credentials.class.php
+++ b/src/main/php/com/amazon/aws/lambda/Credentials.class.php
@@ -1,0 +1,64 @@
+<?php namespace com\amazon\aws\lambda;
+
+use lang\Value;
+use util\Secret;
+
+class Credentials implements Value {
+  private $accessKey, $secretKey, $sessionToken;
+
+  /**
+   * Creates a new instance
+   *
+   * @param  string $accessKey
+   * @param  string|util.Secret $secretKey
+   * @param  ?string $sessionToken
+   */
+  public function __construct($accessKey, $secretKey, $sessionToken= null) {
+    $this->accessKey= $accessKey;
+    $this->secretKey= $secretKey instanceof Secret ? $secretKey : new Secret($secretKey);
+    $this->sessionToken= $sessionToken;
+  }
+
+  /** @return string */
+  public function accessKey() { return $this->accessKey; }
+
+  /** @return util.Secret */
+  public function secretKey() { return $this->secretKey; }
+
+  /** @return ?string */
+  public function sessionToken() { return $this->sessionToken; }
+
+  /** @return string */
+  public function hashCode() {
+    return 'C'.sha1($this->accessKey.$this->secretKey->reveal().$this->sessionToken);
+  }
+
+  /** @return string */
+  public function toString() {
+    return sprintf(
+      '%s(accessKey: %s, secretKey: %s%s)',
+      nameof($this),
+      $this->accessKey,
+      str_repeat('*', strlen($this->secretKey->reveal())),
+      null === $this->sessionToken ? '' : ', sessionToken: '.$this->sessionToken
+    );
+  }
+
+  /**
+   * Comparison
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    if (!($value instanceof self)) return 1;
+
+    $r= $this->accessKey <=> $value->accessKey;
+    if (0 !== $r) return $r;
+
+    $r= $this->sessionToken <=> $value->sessionToken;
+    if (0 !== $r) return $r;
+
+    return $this->secretKey->equals($value->secretKey) ? 0 : 1;
+  }
+}

--- a/src/main/php/com/amazon/aws/lambda/Environment.class.php
+++ b/src/main/php/com/amazon/aws/lambda/Environment.class.php
@@ -56,7 +56,7 @@ class Environment {
     return new Credentials(
       $this->variables['AWS_ACCESS_KEY_ID'],
       $this->variables['AWS_SECRET_ACCESS_KEY'],
-      $this->variables['AWS_SESSION_TOKEN'] ?? null,
+      $this->variables['AWS_SESSION_TOKEN'] ?? null
     );
   }
 

--- a/src/main/php/com/amazon/aws/lambda/Environment.class.php
+++ b/src/main/php/com/amazon/aws/lambda/Environment.class.php
@@ -10,6 +10,7 @@ use util\{FilesystemPropertySource, PropertyAccess};
  * Runtime environment of a lambda
  *
  * @test  com.amazon.aws.lambda.unittest.EnvironmentTest
+ * @see   https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html
  */
 class Environment {
   public $root, $variables, $writer, $properties;
@@ -44,6 +45,19 @@ class Environment {
    */
   public function variable($name) {
     return $this->variables[$name] ?? null;
+  }
+
+  /**
+   * Returns credentials from this environment
+   *
+   * @return com.amazon.aws.lambda.Credentials
+   */
+  public function credentials() {
+    return new Credentials(
+      $this->variables['AWS_ACCESS_KEY_ID'],
+      $this->variables['AWS_SECRET_ACCESS_KEY'],
+      $this->variables['AWS_SESSION_TOKEN'] ?? null,
+    );
   }
 
   /**

--- a/src/test/php/com/amazon/aws/lambda/unittest/EnvironmentTest.class.php
+++ b/src/test/php/com/amazon/aws/lambda/unittest/EnvironmentTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace com\amazon\aws\lambda\unittest;
 
-use com\amazon\aws\lambda\Environment;
+use com\amazon\aws\lambda\{Environment, Credentials};
 use io\streams\{MemoryOutputStream, StringWriter};
 use io\{File, Files, Path};
 use lang\ElementNotFoundException;
@@ -43,6 +43,33 @@ class EnvironmentTest {
   #[Test]
   public function non_existant_variable() {
     Assert::null((new Environment('.', null, []))->variable('TEST'));
+  }
+
+  #[Test]
+  public function credentials() {
+    $env= [
+      'AWS_ACCESS_KEY_ID'     => 'KEY',
+      'AWS_SECRET_ACCESS_KEY' => 'SECRET',
+    ];
+
+    Assert::equals(
+      new Credentials('KEY', 'SECRET'),
+      (new Environment('.', null, $env))->credentials()
+    );
+  }
+
+  #[Test]
+  public function credentials_with_session() {
+    $env= [
+      'AWS_ACCESS_KEY_ID'     => 'KEY',
+      'AWS_SECRET_ACCESS_KEY' => 'SECRET',
+      'AWS_SESSION_TOKEN'     => 'SESSION',
+    ];
+
+    Assert::equals(
+      new Credentials('KEY', 'SECRET', 'SESSION'),
+      (new Environment('.', null, $env))->credentials()
+    );
   }
 
   #[Test]


### PR DESCRIPTION
Access to the access keys obtained from the function's execution role, see https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime

## What this pull request simplifies

Before:

```php
$session= $this->environment->variable('AWS_SESSION_TOKEN');
$access= $this->environment->variable('AWS_ACCESS_KEY_ID');
$secret= new Secret($this->environment->variable('AWS_SECRET_ACCESS_KEY'));
```

After:

```php
$credentials= $this->environment->credentials();
```

## API

```php
public class com.amazon.aws.lambda.Credentials implements lang.Value {
  public function __construct(string $accessKey, string|util.Secret $secretKey, ?string $sessionToken)

  public function accessKey(): string
  public function secretKey(): util.Secret
  public function sessionToken(): ?string
  public function hashCode(): string
  public function toString(): string
  public function compareTo(var $value): int
}
```
