### PR TITLE
Add Environment::endpoint() to return AWS service endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ class Streaming extends Handler {
     return function($event, $context) {
 
       // Send message to WebSocket connection
-      (new ServiceEndpoint('execute-api', $this->environment->credentials()))
+      $this->environment->endpoint('execute-api')
         ->in($context->region)
         ->using($event['requestContext']['apiId'])
         ->resource('/{stage}/@connections/{connectionId}', $event['requestContext'])

--- a/src/main/php/com/amazon/aws/lambda/Environment.class.php
+++ b/src/main/php/com/amazon/aws/lambda/Environment.class.php
@@ -1,6 +1,6 @@
 <?php namespace com\amazon\aws\lambda;
 
-use com\amazon\aws\Credentials;
+use com\amazon\aws\{Credentials, ServiceEndpoint};
 use io\Path;
 use io\streams\StringWriter;
 use lang\{ElementNotFoundException, Environment as System};
@@ -59,6 +59,16 @@ class Environment {
       $this->variables['AWS_SECRET_ACCESS_KEY'],
       $this->variables['AWS_SESSION_TOKEN'] ?? null
     );
+  }
+
+  /**
+   * Returns an endpoint for a given service
+   *
+   * @param  string $service
+   * @return com.amazon.aws.ServiceEndpoint
+   */
+  public function endpoint($service) {
+    return new ServiceEndpoint($service, $this->credentials());
   }
 
   /**

--- a/src/test/php/com/amazon/aws/lambda/unittest/EnvironmentTest.class.php
+++ b/src/test/php/com/amazon/aws/lambda/unittest/EnvironmentTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace com\amazon\aws\lambda\unittest;
 
-use com\amazon\aws\Credentials;
 use com\amazon\aws\lambda\Environment;
+use com\amazon\aws\{Credentials, ServiceEndpoint};
 use io\streams\{MemoryOutputStream, StringWriter};
 use io\{File, Files, Path};
 use lang\ElementNotFoundException;
@@ -70,6 +70,18 @@ class EnvironmentTest {
     Assert::equals(
       new Credentials('KEY', 'SECRET', 'SESSION'),
       (new Environment('.', null, $env))->credentials()
+    );
+  }
+
+  #[Test]
+  public function endpoint() {
+    Assert::equals(
+      'id.execute-api.us-east-1.amazonaws.com',
+      (new Environment('.', null, ['AWS_ACCESS_KEY_ID' => '*', 'AWS_SECRET_ACCESS_KEY' => '*']))
+        ->endpoint('execute-api')
+        ->in('us-east-1')
+        ->using('id')
+        ->domain()
     );
   }
 


### PR DESCRIPTION
Makes it shorter to get AWS service endpoint instances:

```diff
- $endpoint= new ServiceEndpoint('execute-api', $this->environment->credentials());
+ $endpoint= $this->environment->endpoint('execute-api');
```