### PR TITLE
Implement `xp lambda run [Handler]` to run lambdas locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,25 @@ If you need to run any initialization code, you can do before returning the lamb
 
 Development
 -----------
-To test your lambda locally, run the following:
+To run your lambda locally, use the following:
+
+```bash
+$ xp lambda run Greet '{"name":"Timm"}'
+Hello Timm from PHP 8.2.7 via Greet @ test-local-1
+```
+
+*This does not provide a complete lambda environment, and does not have any execution limits imposed on it!*
+
+Integration testing
+-------------------
+To test your lambda inside a local containerized lambda environment, use the *test* command.
 
 ```bash
 $ xp lambda test Greet '{"name":"Timm"}'
 START RequestId: 9ff45cda-df9b-1b8c-c21b-5fe27c8f2d24 Version: $LATEST
 END RequestId: 9ff45cda-df9b-1b8c-c21b-5fe27c8f2d24
 REPORT RequestId: 9ff45cda-df9b-1b8c-c21b-5fe27c8f2d24  Init Duration: 922.19 ms...
-"Hello Timm from PHP 8.0.10 via test @ us-east-1"
+"Hello Timm from PHP 8.2.7 via test @ us-east-1"
 ```
 
 *This functionality is provided by the [AWS Lambda base images for custom runtimes](https://gallery.ecr.aws/lambda/provided)*

--- a/src/main/php/com/amazon/aws/lambda/Environment.class.php
+++ b/src/main/php/com/amazon/aws/lambda/Environment.class.php
@@ -38,6 +38,11 @@ class Environment {
     return new Path(sys_get_temp_dir());
   }
 
+  /** Returns whether this is a local invocation */
+  public function local(): bool {
+    return isset($this->variables['AWS_LOCAL']);
+  }
+
   /**
    * Returns a given environment variable
    *

--- a/src/main/php/xp/lambda/RunLambda.class.php
+++ b/src/main/php/xp/lambda/RunLambda.class.php
@@ -35,7 +35,7 @@ class RunLambda {
     $region= getenv('AWS_REGION') ?: self::REGION;
     $functionArn= "arn:aws:lambda:{$region}:123456789012:function:{$name}";
     $deadlineMs= (time() + 900) * 1000;
-    $environment= $_ENV + ['AWS_LAMBDA_FUNCTION_NAME' => $name, 'AWS_REGION' => $region];
+    $environment= $_ENV + ['AWS_LAMBDA_FUNCTION_NAME' => $name, 'AWS_REGION' => $region, 'AWS_LOCAL' => true];
 
     try {
       $target= $this->impl->newInstance(new Environment(getcwd(), Console::$out, $environment))->target();

--- a/src/main/php/xp/lambda/RunLambda.class.php
+++ b/src/main/php/xp/lambda/RunLambda.class.php
@@ -41,7 +41,7 @@ class RunLambda {
       $lambda= $target instanceof Lambda ? [$target, 'process'] : $target;
     } catch (Throwable $e) {
       Console::$err->writeLine($e);
-      return 1;
+      return 127;
     }
 
     $status= 0;

--- a/src/main/php/xp/lambda/RunLambda.class.php
+++ b/src/main/php/xp/lambda/RunLambda.class.php
@@ -1,0 +1,61 @@
+<?php namespace xp\lambda;
+
+use com\amazon\aws\lambda\{Environment, Context};
+use lang\{XPClass, Throwable};
+use util\UUID;
+use util\cmd\Console;
+
+/**
+ * Run lambdas locally
+ *
+ * @see https://docs.aws.amazon.com/de_de/lambda/latest/dg/runtimes-api.html
+ */
+class RunLambda {
+  const TRACE_ID= 'Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419;Sampled=1';
+
+  private $impl, $length, $event;
+
+  /**
+   * Creates a new `run` subcommand
+   *
+   * @param  string $handler
+   * @param  ?string $event
+   * @throws lang.ClassLoadingException
+   */
+  public function __construct($handler, $event= null) {
+    $this->impl= XPClass::forName($handler);
+    if (null === $event) {
+      $this->length= 0;
+      $this->event= null;
+    } else {
+      $this->length= strlen($event);
+      $this->event= json_decode($event, true);
+    }    
+  }
+
+  /** Runs this command */
+  public function run(): int {
+    $name= $this->impl->getSimpleName();
+    $region= getenv('AWS_REGION') ?: 'test-local-1';
+    $context= new Context(
+      [
+        'Lambda-Runtime-Aws-Request-Id'       => [UUID::randomUUID()->hashCode()],
+        'Lambda-Runtime-Invoked-Function-Arn' => ["arn:aws:lambda:{$region}:123456789012:function:{$name}"],
+        'Lambda-Runtime-Trace-Id'             => [self::TRACE_ID],
+        'Lambda-Runtime-Deadline-Ms'          => [(time() + 900) * 1000],
+        'Content-Length'                      => [$this->length],
+      ],
+      $_ENV + ['AWS_LAMBDA_FUNCTION_NAME' => $name, 'AWS_REGION' => $region]
+    );
+    
+    try {
+      $lambda= $this->impl->newInstance(new Environment(getcwd(), Console::$out, []))->target();
+      $result= $lambda instanceof Lambda ? $lambda->process($this->event, $context) : $lambda($this->event, $context);
+      Console::$out->writeLine($result);
+      return 0;
+    } catch (Throwable $e) {
+      Console::$err->writeLine($e);
+      return 1;
+    }
+  }
+}

--- a/src/main/php/xp/lambda/RunLambda.class.php
+++ b/src/main/php/xp/lambda/RunLambda.class.php
@@ -11,7 +11,8 @@ use util\cmd\Console;
  * @see https://docs.aws.amazon.com/de_de/lambda/latest/dg/runtimes-api.html
  */
 class RunLambda {
-  const TRACE_ID= 'Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419;Sampled=1';
+  const TRACE= 'Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419;Sampled=1';
+  const REGION= 'test-local-1';
 
   private $impl, $events;
 
@@ -30,7 +31,7 @@ class RunLambda {
   /** Runs this command */
   public function run(): int {
     $name= $this->impl->getSimpleName();
-    $region= getenv('AWS_REGION') ?: 'test-local-1';
+    $region= getenv('AWS_REGION') ?: self::REGION;
     $functionArn= "arn:aws:lambda:{$region}:123456789012:function:{$name}";
     $deadlineMs= (time() + 900) * 1000;
     $environment= $_ENV + ['AWS_LAMBDA_FUNCTION_NAME' => $name, 'AWS_REGION' => $region];
@@ -48,7 +49,7 @@ class RunLambda {
       $headers= [
         'Lambda-Runtime-Aws-Request-Id'       => [UUID::randomUUID()->hashCode()],
         'Lambda-Runtime-Invoked-Function-Arn' => [$functionArn],
-        'Lambda-Runtime-Trace-Id'             => [self::TRACE_ID],
+        'Lambda-Runtime-Trace-Id'             => [self::TRACE],
         'Lambda-Runtime-Deadline-Ms'          => [$deadlineMs],
         'Content-Length'                      => [strlen($event)],
       ];

--- a/src/main/php/xp/lambda/RunLambda.class.php
+++ b/src/main/php/xp/lambda/RunLambda.class.php
@@ -9,7 +9,7 @@ use util\cmd\Console;
  * Run lambdas locally
  *
  * @see https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtime-environment.html
- * @see https://docs.aws.amazon.com/de_de/lambda/latest/dg/runtimes-api.html
+ * @see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html
  */
 class RunLambda {
   const TRACE= 'Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419;Sampled=1';

--- a/src/main/php/xp/lambda/RunLambda.class.php
+++ b/src/main/php/xp/lambda/RunLambda.class.php
@@ -8,6 +8,7 @@ use util\cmd\Console;
 /**
  * Run lambdas locally
  *
+ * @see https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtime-environment.html
  * @see https://docs.aws.amazon.com/de_de/lambda/latest/dg/runtimes-api.html
  */
 class RunLambda {

--- a/src/main/php/xp/lambda/RunLambda.class.php
+++ b/src/main/php/xp/lambda/RunLambda.class.php
@@ -37,7 +37,7 @@ class RunLambda {
     $environment= $_ENV + ['AWS_LAMBDA_FUNCTION_NAME' => $name, 'AWS_REGION' => $region];
 
     try {
-      $target= $this->impl->newInstance(new Environment(getcwd(), Console::$out, []))->target();
+      $target= $this->impl->newInstance(new Environment(getcwd(), Console::$out, $environment))->target();
       $lambda= $target instanceof Lambda ? [$target, 'process'] : $target;
     } catch (Throwable $e) {
       Console::$err->writeLine($e);

--- a/src/main/php/xp/lambda/Runner.class.php
+++ b/src/main/php/xp/lambda/Runner.class.php
@@ -70,7 +70,7 @@ class Runner {
     sscanf($name, "%[^:]:%[^\r]", $command, $version);
     switch ($command) {
       case 'package': return new PackageLambda(new Path('function.zip'), new Sources(new Path('.'), [...$args, 'vendor']));
-      case 'run': return new RunLambda($args[0], $args[1] ?? null);
+      case 'run': return new RunLambda(...$args);
       case 'runtime': return new CreateRuntime(self::resolve($version), new Path('runtime-%s.zip'), in_array('-b', $args));
       case 'test': return new TestLambda(self::resolve($version), new Path('.'), $args);
       default: return new DisplayError('Unknown command "'.$args[0].'"');

--- a/src/main/php/xp/lambda/Runner.class.php
+++ b/src/main/php/xp/lambda/Runner.class.php
@@ -8,6 +8,26 @@ use text\json\{Json, StreamInput};
  * XP AWS Lambda
  * =============
  *
+ * - Run lambda locally:
+ *   ```sh
+ *   $ xp lambda run Greet '{"name":"Test"}'
+ *   ```
+ * - Package single file in `function.zip` file for deployment:
+ *   ```sh
+ *   $ xp lambda package Greet.class.php
+ *   ```
+ * - Package INI file and source directory in `function.zip`:
+ *   ```sh
+ *   $ xp lambda package task.ini src/main/php
+ *   ```
+ * - Test lambda inside a containerized AWS environment:
+ *   ```sh
+ *   $ xp lambda test Greet '{"name":"Test"}'
+ *   ```
+ * - Test lambda, pass environment variables:
+ *   ```sh
+ *   $ xp lambda test -e PROFILE=prod Audit
+ *   ```
  * - Store runtime layer as `runtime-X.X.X.zip`, building if necessary:
  *   ```sh
  *   $ xp lambda runtime
@@ -20,23 +40,7 @@ use text\json\{Json, StreamInput};
  *   ```sh
  *   $ xp lambda runtime:8.0
  *   ```
- * - Test lambda:
- *   ```sh
- *   $ xp lambda test Greet '{"name":"Test"}'
- *   ```
- * - Test lambda, pass environment variables:
- *   ```sh
- *   $ xp lambda test -e PROFILE=prod Audit
- *   ```
- * - Package single file in `function.zip` file for deployment:
- *   ```sh
- *   $ xp lambda package Greet.class.php
- *   ```
- * - Package INI file and source directory in `function.zip`:
- *   ```sh
- *   $ xp lambda package task.ini src/main/php
- *   ```
- * The `runtime` and `test` commands require Docker or Podman to be installed!
+ * The `test` and `runtime` commands require Docker or Podman to be installed!
  * Packaging will always include the `vendor` directory automatically.
  */
 class Runner {
@@ -66,6 +70,7 @@ class Runner {
     sscanf($name, "%[^:]:%[^\r]", $command, $version);
     switch ($command) {
       case 'package': return new PackageLambda(new Path('function.zip'), new Sources(new Path('.'), [...$args, 'vendor']));
+      case 'run': return new RunLambda($args[0], $args[1] ?? null);
       case 'runtime': return new CreateRuntime(self::resolve($version), new Path('runtime-%s.zip'), in_array('-b', $args));
       case 'test': return new TestLambda(self::resolve($version), new Path('.'), $args);
       default: return new DisplayError('Unknown command "'.$args[0].'"');

--- a/src/test/php/com/amazon/aws/lambda/unittest/EnvironmentTest.class.php
+++ b/src/test/php/com/amazon/aws/lambda/unittest/EnvironmentTest.class.php
@@ -47,6 +47,16 @@ class EnvironmentTest {
   }
 
   #[Test]
+  public function not_local_by_default() {
+    Assert::false((new Environment('.', null, []))->local());
+  }
+
+  #[Test]
+  public function local() {
+    Assert::true((new Environment('.', null, ['AWS_LOCAL' => true]))->local());
+  }
+
+  #[Test]
   public function credentials() {
     $env= [
       'AWS_ACCESS_KEY_ID'     => 'KEY',


### PR DESCRIPTION
## Declaration

Inside a file called *Greet.class.php*:

```php
use com\amazon\aws\lambda\Handler;

class Greet extends Handler {

  /** @return com.amazon.aws.lambda.Lambda|callable */
  public function target() {
    return fn($event, $context) => sprintf(
      'Hello %s from PHP %s via %s @ %s',
      $event['name'] ?? 'world',
      PHP_VERSION,
      $context->functionName,
      $context->region
    );
  }
}
```

## Invocation

In a shell window:

```bash
$ xp lambda run Greet
Hello world from PHP 8.2.7 via Greet @ test-local-1

# Will take environment variables into account
$ AWS_REGION=eu-central-1 xp lambda run Greet
Hello world from PHP 8.2.7 via Greet @ eu-central-1

# Specify payload as JSON
$ xp lambda run Greet '{"name":"Timm"}'
Hello Timm from PHP 8.2.7 via Greet @ test-local-1

# Can be invoked with multiple payloads, initializing only once
$ xp lambda run Greet '{"name":"Timm"}' '{"name":"Alex"}'
Hello Timm from PHP 8.2.7 via Greet @ test-local-1
Hello Alex from PHP 8.2.7 via Greet @ test-local-1
```

* * * 

*Note: The output will not contain the typical telemetry information displayed in CloudWatch / Lambda console (`START RequestId / END RequestId / REPORT ...`). To run your lambda in something closer to the actual execution environment use `xp lambda test`.*