### PR TITLE
Resolve paths in symlinks before adding to ZIP file

### DIFF
--- a/src/main/php/xp/lambda/PackageLambda.class.php
+++ b/src/main/php/xp/lambda/PackageLambda.class.php
@@ -38,7 +38,8 @@ class PackageLambda {
     // - Files: Add to ZIP
     // - Folders: Recursively add all subfolders and files therein
     if (Sources::IS_LINK === ($stat['mode'] & Sources::IS_LINK)) {
-      $resolved= $path->parent()->resolve(readlink($path))->asRealpath($base);
+      $target= new Path(readlink($path));
+      $resolved= Path::real($target->isAbsolute() ? $target : [$path->parent(), $target], $base);
       if ($resolved->exists()) {
         $base= $resolved->isFile() ? new Path(dirname($resolved)) : $resolved;
         yield from $this->add($zip, $resolved, $base, $relative.DIRECTORY_SEPARATOR);

--- a/src/main/php/xp/lambda/PackageLambda.class.php
+++ b/src/main/php/xp/lambda/PackageLambda.class.php
@@ -8,6 +8,7 @@ use util\cmd\Console;
 class PackageLambda {
   const COMPRESSION_THRESHOLD= 24;
 
+  // See https://www.php.net/manual/en/function.fileperms.php
   const IS_LINK= 0120000;
   const IS_FILE= 0100000;
   const IS_FOLDER= 0040000;

--- a/src/main/php/xp/lambda/PackageLambda.class.php
+++ b/src/main/php/xp/lambda/PackageLambda.class.php
@@ -43,9 +43,11 @@ class PackageLambda {
     // - Files: Add to ZIP
     // - Folders: Recursively add all subfolders and files therein
     if (self::IS_LINK === ($stat['mode'] & self::IS_LINK)) {
-      $resolved= new Path(readlink($path));
-      $base= $resolved->isFile() ? new Path(dirname($resolved)) : $resolved;
-      yield from $this->add($zip, $resolved, $base, $relative.DIRECTORY_SEPARATOR);
+      $resolved= Path::real([dirname($path), readlink($path)], $base);
+      if ($resolved->exists()) {
+        $base= $resolved->isFile() ? new Path(dirname($resolved)) : $resolved;
+        yield from $this->add($zip, $resolved, $base, $relative.DIRECTORY_SEPARATOR);
+      }
     } else if (self::IS_FILE === ($stat['mode'] & self::IS_FILE)) {
       $file= $zip->add(new ZipFileEntry($relative));
 

--- a/src/main/php/xp/lambda/PackageLambda.class.php
+++ b/src/main/php/xp/lambda/PackageLambda.class.php
@@ -5,6 +5,7 @@ use io\archive\zip\{ZipFile, ZipArchiveWriter, ZipDirEntry, ZipFileEntry, Compre
 use io\streams\StreamTransfer;
 use util\cmd\Console;
 
+/** @test com.amazon.aws.lambda.unittest.PackagingTest */
 class PackageLambda {
   const COMPRESSION_THRESHOLD= 24;
 

--- a/src/main/php/xp/lambda/PackageLambda.class.php
+++ b/src/main/php/xp/lambda/PackageLambda.class.php
@@ -68,7 +68,17 @@ class PackageLambda {
     $z= ZipFile::create($this->target->asFile()->out());
 
     $sources= iterator_to_array($this->sources);
-    $total= sizeof($sources) + 1;
+    $total= sizeof($sources);
+
+    // Add class path file to root if existant
+    $p= new Path($this->sources->base, 'class.pth');
+    if ($p->exists()) {
+      $file= $z->add(new ZipFileEntry('class.pth'));
+      $file->out()->write(preg_replace($this->exclude.'m', '?$1', file_get_contents($p)));
+      Console::writeLinef("\e[34m => [1/%d] class.pth\e[0m", ++$total);
+    }
+
+    // Add all other sources
     foreach ($sources as $i => $source) {
       Console::writef("\e[34m => [%d/%d] ", $i + 1, $total);
       $entries= 0;
@@ -78,10 +88,6 @@ class PackageLambda {
       }
       Console::writeLine("\e[0m");
     }
-
-    $file= $z->add(new ZipFileEntry('class.pth'));
-    $file->out()->write(preg_replace($this->exclude.'m', '?$1', file_get_contents('class.pth')));
-    Console::writeLinef("\e[34m => [%1\$d/%1\$d] class.pth\e[0m", $total);
 
     $z->close();
     Console::writeLine();

--- a/src/main/php/xp/lambda/PackageLambda.class.php
+++ b/src/main/php/xp/lambda/PackageLambda.class.php
@@ -40,10 +40,15 @@ class PackageLambda {
     if (Sources::IS_LINK === ($stat['mode'] & Sources::IS_LINK)) {
       $target= new Path(readlink($path));
       $resolved= Path::real($target->isAbsolute() ? $target : [$path->parent(), $target], $base);
-      if ($resolved->exists()) {
-        $base= $resolved->isFile() ? new Path(dirname($resolved)) : $resolved;
-        yield from $this->add($zip, $resolved, $base, $relative.DIRECTORY_SEPARATOR);
+      if (!$resolved->exists()) return;
+
+      if ($resolved->isFile()) {
+        $base= new Path(dirname($resolved));
+        $relative= dirname($relative);
+      } else {
+        $base= $resolved;
       }
+      yield from $this->add($zip, $resolved, $base, $relative.DIRECTORY_SEPARATOR);
     } else if (Sources::IS_FILE === ($stat['mode'] & Sources::IS_FILE)) {
       $file= $zip->add(new ZipFileEntry($relative));
 

--- a/src/main/php/xp/lambda/PackageLambda.class.php
+++ b/src/main/php/xp/lambda/PackageLambda.class.php
@@ -38,7 +38,7 @@ class PackageLambda {
     // - Files: Add to ZIP
     // - Folders: Recursively add all subfolders and files therein
     if (Sources::IS_LINK === ($stat['mode'] & Sources::IS_LINK)) {
-      $resolved= Path::real([dirname($path), readlink($path)], $base);
+      $resolved= $path->parent()->resolve(readlink($path))->asRealpath($base);
       if ($resolved->exists()) {
         $base= $resolved->isFile() ? new Path(dirname($resolved)) : $resolved;
         yield from $this->add($zip, $resolved, $base, $relative.DIRECTORY_SEPARATOR);

--- a/src/main/php/xp/lambda/Sources.class.php
+++ b/src/main/php/xp/lambda/Sources.class.php
@@ -16,7 +16,7 @@ class Sources implements IteratorAggregate {
   public function getIterator(): Traversable {
     $seen= [];
     foreach ($this->sources as $source) {
-      $path= ($source instanceof Path ? $source : new Path($source))->asRealpath();
+      $path= ($source instanceof Path ? $source : new Path($source))->asRealpath($this->base);
 
       $key= $path->hashCode(); 
       if (isset($seen[$key])) continue;

--- a/src/main/php/xp/lambda/Sources.class.php
+++ b/src/main/php/xp/lambda/Sources.class.php
@@ -5,6 +5,12 @@ use io\Path;
 
 /** Returns a unique list of sources */
 class Sources implements IteratorAggregate {
+
+  // See https://www.php.net/manual/en/function.fileperms.php
+  const IS_LINK= 0120000;
+  const IS_FILE= 0100000;
+  const IS_FOLDER= 0040000;
+
   public $base;
   private $sources;
 

--- a/src/test/php/com/amazon/aws/lambda/unittest/PackagingTest.class.php
+++ b/src/test/php/com/amazon/aws/lambda/unittest/PackagingTest.class.php
@@ -18,8 +18,15 @@ class PackagingTest {
   }
 
   #[After]
-  private function cleanup() {
-    $this->tempDir->unlink();
+  private function cleanup(Folder $folder= null) {
+    $folder ?? $folder= $this->tempDir;
+    foreach ($folder->entries() as $entry) {
+      switch ($m= lstat($entry)['mode'] & 0170000) {
+        case PackageLambda::IS_LINK: unlink($entry); break;
+        case PackageLambda::IS_FILE: $entry->asFile()->unlink(); break;
+        case PackageLambda::IS_FOLDER: $this->cleanup($entry->asFolder()); break;
+      }
+    }
   }
 
   /** Creates files and directory from given definitions */
@@ -28,12 +35,16 @@ class PackagingTest {
     // Create sources from definitions
     foreach ($definitions as $name => $definition) {
       switch ($definition[0]) {
-        case 'file':
+        case PackageLambda::IS_FILE:
           Files::write(new File($this->tempDir, $name), $definition[1]);
           break;
 
-        case 'dir':
+        case PackageLambda::IS_FOLDER:
           (new Folder($this->tempDir, $name))->create($definition[1]);
+          break;
+
+        case PackageLambda::IS_LINK:
+          symlink($definition[1], new Path($this->tempDir, $name));
           break;
       }
     }
@@ -60,7 +71,7 @@ class PackagingTest {
 
   #[Test]
   public function single_file() {
-    $zip= $this->package(new Sources($this->create(['file.txt' => ['file', 'Test']]), ['file.txt']));
+    $zip= $this->package(new Sources($this->create(['file.txt' => [PackageLambda::IS_FILE, 'Test']]), ['file.txt']));
 
     $file= $zip->next();
     Assert::equals('file.txt', $file->getName());
@@ -70,7 +81,7 @@ class PackagingTest {
 
   #[Test]
   public function single_directory() {
-    $zip= $this->package(new Sources($this->create(['src' => ['dir', 0755]]), ['src']));
+    $zip= $this->package(new Sources($this->create(['src' => [PackageLambda::IS_FOLDER, 0755]]), ['src']));
 
     $dir= $zip->next();
     Assert::equals('src/', $dir->getName());
@@ -81,8 +92,8 @@ class PackagingTest {
   #[Test]
   public function file_inside_directory() {
     $path= $this->create([
-      'src'          => ['dir', 0755],
-      'src/file.txt' => ['file', 'Test']
+      'src'          => [PackageLambda::IS_FOLDER, 0755],
+      'src/file.txt' => [PackageLambda::IS_FILE, 'Test']
     ]);
     $zip= $this->package(new Sources($path, ['src']));
 
@@ -93,6 +104,42 @@ class PackagingTest {
     $file= $zip->next();
     Assert::equals('src/file.txt', $file->getName());
     Assert::equals(4, $file->getSize());
+
+    Assert::false($zip->hasNext());
+  }
+
+  #[Test]
+  public function link_inside_directory() {
+    $path= $this->create([
+      'core/'                => [PackageLambda::IS_FOLDER, 0755],
+      'core/composer.json'   => [PackageLambda::IS_FILE, '{"require":{"php":">=7.0"}}'],
+      'project'              => [PackageLambda::IS_FOLDER, 0755],
+      'project/src'          => [PackageLambda::IS_FOLDER, 0755],
+      'project/src/file.txt' => [PackageLambda::IS_FILE, 'Test'],
+      'project/lib'          => [PackageLambda::IS_FOLDER, 0755],
+      'project/lib/core'     => [PackageLambda::IS_LINK, '../../core'],
+    ]);
+    $zip= $this->package(new Sources(new Path($path, 'project'), ['src', 'lib']));
+
+    $dir= $zip->next();
+    Assert::equals('src/', $dir->getName());
+    Assert::true($dir->isDirectory());
+
+    $file= $zip->next();
+    Assert::equals('src/file.txt', $file->getName());
+    Assert::equals(4, $file->getSize());
+
+    $lib= $zip->next();
+    Assert::equals('lib/', $lib->getName());
+    Assert::true($lib->isDirectory());
+
+    $core= $zip->next();
+    Assert::equals('lib/core/', $core->getName());
+    Assert::true($core->isDirectory());
+
+    $composer= $zip->next();
+    Assert::equals('lib/core/composer.json', $composer->getName());
+    Assert::equals(27, $composer->getSize());
 
     Assert::false($zip->hasNext());
   }

--- a/src/test/php/com/amazon/aws/lambda/unittest/PackagingTest.class.php
+++ b/src/test/php/com/amazon/aws/lambda/unittest/PackagingTest.class.php
@@ -73,7 +73,7 @@ class PackagingTest {
     $zip= $this->package(new Sources($this->create(['src' => ['dir', 0755]]), ['src']));
 
     $dir= $zip->next();
-    Assert::equals('src'.DIRECTORY_SEPARATOR, $dir->getName());
+    Assert::equals('src/', $dir->getName());
     Assert::true($dir->isDirectory());
     Assert::false($zip->hasNext());
   }

--- a/src/test/php/com/amazon/aws/lambda/unittest/PackagingTest.class.php
+++ b/src/test/php/com/amazon/aws/lambda/unittest/PackagingTest.class.php
@@ -87,11 +87,11 @@ class PackagingTest {
     $zip= $this->package(new Sources($path, ['src']));
 
     $dir= $zip->next();
-    Assert::equals('src'.DIRECTORY_SEPARATOR, $dir->getName());
+    Assert::equals('src/', $dir->getName());
     Assert::true($dir->isDirectory());
 
     $file= $zip->next();
-    Assert::equals('src'.DIRECTORY_SEPARATOR.'file.txt', $file->getName());
+    Assert::equals('src/file.txt', $file->getName());
     Assert::equals(4, $file->getSize());
 
     Assert::false($zip->hasNext());

--- a/src/test/php/com/amazon/aws/lambda/unittest/PackagingTest.class.php
+++ b/src/test/php/com/amazon/aws/lambda/unittest/PackagingTest.class.php
@@ -65,6 +65,7 @@ class PackagingTest {
     $file= $zip->next();
     Assert::equals('file.txt', $file->getName());
     Assert::equals(4, $file->getSize());
+    Assert::false($zip->hasNext());
   }
 
   #[Test]
@@ -74,6 +75,7 @@ class PackagingTest {
     $dir= $zip->next();
     Assert::equals('src'.DIRECTORY_SEPARATOR, $dir->getName());
     Assert::true($dir->isDirectory());
+    Assert::false($zip->hasNext());
   }
 
   #[Test]
@@ -91,5 +93,7 @@ class PackagingTest {
     $file= $zip->next();
     Assert::equals('src'.DIRECTORY_SEPARATOR.'file.txt', $file->getName());
     Assert::equals(4, $file->getSize());
+
+    Assert::false($zip->hasNext());
   }
 }

--- a/src/test/php/com/amazon/aws/lambda/unittest/PackagingTest.class.php
+++ b/src/test/php/com/amazon/aws/lambda/unittest/PackagingTest.class.php
@@ -4,6 +4,7 @@ use io\archive\zip\{ZipFile, ZipIterator};
 use io\streams\MemoryOutputStream;
 use io\{File, Files, Folder, Path};
 use lang\Environment;
+use test\verify\Runtime;
 use test\{After, Assert, Before, Test, Values};
 use util\cmd\Console;
 use xp\lambda\{PackageLambda, Sources};
@@ -109,7 +110,7 @@ class PackagingTest {
     Assert::false($zip->hasNext());
   }
 
-  #[Test, Values(['../../core', '%s/core'])]
+  #[Test, Runtime(os: 'Linux'), Values(['../../core', '%s/core'])]
   public function link_inside_directory($target) {
     $link= sprintf($target, rtrim($this->tempDir->getURI(), DIRECTORY_SEPARATOR));
     $path= $this->create([

--- a/src/test/php/com/amazon/aws/lambda/unittest/PackagingTest.class.php
+++ b/src/test/php/com/amazon/aws/lambda/unittest/PackagingTest.class.php
@@ -22,9 +22,9 @@ class PackagingTest {
     $folder ?? $folder= $this->tempDir;
     foreach ($folder->entries() as $entry) {
       switch ($m= lstat($entry)['mode'] & 0170000) {
-        case PackageLambda::IS_LINK: unlink($entry); break;
-        case PackageLambda::IS_FILE: $entry->asFile()->unlink(); break;
-        case PackageLambda::IS_FOLDER: $this->cleanup($entry->asFolder()); break;
+        case Sources::IS_LINK: unlink($entry); break;
+        case Sources::IS_FILE: $entry->asFile()->unlink(); break;
+        case Sources::IS_FOLDER: $this->cleanup($entry->asFolder()); break;
       }
     }
   }
@@ -35,15 +35,15 @@ class PackagingTest {
     // Create sources from definitions
     foreach ($definitions as $name => $definition) {
       switch ($definition[0]) {
-        case PackageLambda::IS_FILE:
+        case Sources::IS_FILE:
           Files::write(new File($this->tempDir, $name), $definition[1]);
           break;
 
-        case PackageLambda::IS_FOLDER:
+        case Sources::IS_FOLDER:
           (new Folder($this->tempDir, $name))->create($definition[1]);
           break;
 
-        case PackageLambda::IS_LINK:
+        case Sources::IS_LINK:
           symlink($definition[1], new Path($this->tempDir, $name));
           break;
       }
@@ -71,7 +71,7 @@ class PackagingTest {
 
   #[Test]
   public function single_file() {
-    $zip= $this->package(new Sources($this->create(['file.txt' => [PackageLambda::IS_FILE, 'Test']]), ['file.txt']));
+    $zip= $this->package(new Sources($this->create(['file.txt' => [Sources::IS_FILE, 'Test']]), ['file.txt']));
 
     $file= $zip->next();
     Assert::equals('file.txt', $file->getName());
@@ -81,7 +81,7 @@ class PackagingTest {
 
   #[Test]
   public function single_directory() {
-    $zip= $this->package(new Sources($this->create(['src' => [PackageLambda::IS_FOLDER, 0755]]), ['src']));
+    $zip= $this->package(new Sources($this->create(['src' => [Sources::IS_FOLDER, 0755]]), ['src']));
 
     $dir= $zip->next();
     Assert::equals('src/', $dir->getName());
@@ -92,8 +92,8 @@ class PackagingTest {
   #[Test]
   public function file_inside_directory() {
     $path= $this->create([
-      'src'          => [PackageLambda::IS_FOLDER, 0755],
-      'src/file.txt' => [PackageLambda::IS_FILE, 'Test']
+      'src'          => [Sources::IS_FOLDER, 0755],
+      'src/file.txt' => [Sources::IS_FILE, 'Test']
     ]);
     $zip= $this->package(new Sources($path, ['src']));
 
@@ -111,13 +111,13 @@ class PackagingTest {
   #[Test]
   public function link_inside_directory() {
     $path= $this->create([
-      'core/'                => [PackageLambda::IS_FOLDER, 0755],
-      'core/composer.json'   => [PackageLambda::IS_FILE, '{"require":{"php":">=7.0"}}'],
-      'project'              => [PackageLambda::IS_FOLDER, 0755],
-      'project/src'          => [PackageLambda::IS_FOLDER, 0755],
-      'project/src/file.txt' => [PackageLambda::IS_FILE, 'Test'],
-      'project/lib'          => [PackageLambda::IS_FOLDER, 0755],
-      'project/lib/core'     => [PackageLambda::IS_LINK, '../../core'],
+      'core/'                => [Sources::IS_FOLDER, 0755],
+      'core/composer.json'   => [Sources::IS_FILE, '{"require":{"php":">=7.0"}}'],
+      'project'              => [Sources::IS_FOLDER, 0755],
+      'project/src'          => [Sources::IS_FOLDER, 0755],
+      'project/src/file.txt' => [Sources::IS_FILE, 'Test'],
+      'project/lib'          => [Sources::IS_FOLDER, 0755],
+      'project/lib/core'     => [Sources::IS_LINK, '../../core'],
     ]);
     $zip= $this->package(new Sources(new Path($path, 'project'), ['src', 'lib']));
 

--- a/src/test/php/com/amazon/aws/lambda/unittest/PackagingTest.class.php
+++ b/src/test/php/com/amazon/aws/lambda/unittest/PackagingTest.class.php
@@ -4,7 +4,7 @@ use io\archive\zip\{ZipFile, ZipIterator};
 use io\streams\MemoryOutputStream;
 use io\{File, Files, Folder, Path};
 use lang\Environment;
-use test\{After, Assert, Before, Test};
+use test\{After, Assert, Before, Test, Values};
 use util\cmd\Console;
 use xp\lambda\{PackageLambda, Sources};
 
@@ -31,6 +31,7 @@ class PackagingTest {
 
   /** Creates files and directory from given definitions */
   private function create(array $definitions): Path {
+    $this->cleanup();
 
     // Create sources from definitions
     foreach ($definitions as $name => $definition) {
@@ -108,8 +109,9 @@ class PackagingTest {
     Assert::false($zip->hasNext());
   }
 
-  #[Test]
-  public function link_inside_directory() {
+  #[Test, Values(['../../core', '%s/core'])]
+  public function link_inside_directory($target) {
+    $link= sprintf($target, rtrim($this->tempDir->getURI(), DIRECTORY_SEPARATOR));
     $path= $this->create([
       'core/'                => [Sources::IS_FOLDER, 0755],
       'core/composer.json'   => [Sources::IS_FILE, '{"require":{"php":">=7.0"}}'],
@@ -117,7 +119,7 @@ class PackagingTest {
       'project/src'          => [Sources::IS_FOLDER, 0755],
       'project/src/file.txt' => [Sources::IS_FILE, 'Test'],
       'project/lib'          => [Sources::IS_FOLDER, 0755],
-      'project/lib/core'     => [Sources::IS_LINK, '../../core'],
+      'project/lib/core'     => [Sources::IS_LINK, $link],
     ]);
     $zip= $this->package(new Sources(new Path($path, 'project'), ['src', 'lib']));
 


### PR DESCRIPTION
See #25, now produces the following ZIP file:

```diff
 $ unzip -l function.zip
 Archive:  function.zip
   Length      Date    Time    Name
 ---------  ---------- -----   ----
         0  2023-10-06 16:29   vendor/
         0  2023-10-06 16:29   vendor/enbwag/
         0  2023-10-06 16:29   vendor/enbwag/empower-foundation/
-        0  2023-10-06 16:29   ../../lib/empower-foundation/src/
+        0  2023-10-08 09:49   vendor/enbwag/empower-foundation/src/
 [...]
```