### PR TITLE
Migrate from AL2 to AL2023

### DIFF
--- a/src/main/php/xp/lambda/Dockerfile.runtime
+++ b/src/main/php/xp/lambda/Dockerfile.runtime
@@ -1,9 +1,9 @@
-FROM public.ecr.aws/lambda/provided:al2 as builder
+FROM public.ecr.aws/lambda/provided:al2023 AS builder
 
 ARG php_version="?.?.?"
 ARG xp_version="?.?.?"
 
-RUN yum clean all && yum install -y \
+RUN dnf clean all && dnf install -y \
   autoconf \
   gcc \
   gcc-c++ \

--- a/src/main/php/xp/lambda/Dockerfile.test
+++ b/src/main/php/xp/lambda/Dockerfile.test
@@ -1,9 +1,9 @@
 ARG php_version="?.?.?"
 ARG xp_version="?.?.?"
 
-FROM lambda-xp-runtime:${php_version} as build
+FROM lambda-xp-runtime:${php_version} AS build
 
-FROM public.ecr.aws/lambda/provided:al2
+FROM public.ecr.aws/lambda/provided:al2023
 
 COPY --from=build /opt/php/bin/ /opt/bin/
 
@@ -14,8 +14,9 @@ RUN echo $'#!/bin/sh\n\n\
 export _HANDLER="$1"\n\
 /usr/local/bin/aws-lambda-rie /var/runtime/bootstrap --log-level error &\n\
 pid=$!\n\
-curl -s "http://localhost:8080/2015-03-31/functions/function/invocations" -d "$2"\n\
+timeout 10 sh -c "until cat < /dev/null > /dev/tcp/127.0.0.1/9001 ; do sleep 0.1; done" 2>/dev/null\n\
+curl -s "http://127.0.0.1:8080/2015-03-31/functions/function/invocations" -d "$2"\n\
 kill -2 $pid\n\
 echo' > /lambda-entrypoint.sh
 
-ENV TZ UTC
+ENV TZ=UTC


### PR DESCRIPTION
> Amazon Linux 2 end of support date (End of Life, or EOL) will be on 2026-06-30.
>
> Customers need to migrate to Amazon Linux 2023 (AL2023) prior to the AL2’s end of support (EOS)
> AL2023 is the latest version of Amazon Linux which offers enhanced security features including FIPS certification, modern package versions, improved performance, and support until June 2029.

Source: https://aws.amazon.com/amazon-linux-2/faqs/

* * * 

See also:

* https://docs.aws.amazon.com/linux/al2023/ug/compare-with-al2.html
* https://gallery.ecr.aws/lambda/provided
